### PR TITLE
Sublime linter 4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ For general information on how SublimeLinter works with settings, please see [Se
 
 You can configure `slim-lint` options in the way you would from the command line, with `.slim-lint.yml` files. If a `.slim-lint.yml` file is not found in the file hierarchy starting with the linted file, your home directory will also be searched. For more information, see the [slim-lint page][slim-lint]. Default configuration file can be found [here](https://github.com/sds/slim-lint/blob/master/config/default.yml).
 
+To override the config file path, you would add this to the Sublime Linter User Settings:
+
+```json
+"slimlint": {
+    "args": ["--config", "path/to/config.yml"]
+}
+```
+
+If you are using Bundler and would like to use the locked rubocop version (which will also allow you to use `inherit_gem` in `rubocop.yml`, in case you are inheriting from another gem in the project), you must set `use_bundle_exec` to true:
+
+```json
+"slimlint": {
+    "use_bundle_exec": true
+}
+```
+
+You can configure the rubocop config file location:
+
+```json
+"slimlint": {
+  "rubocop_config": "path/to/config.yml"
+}
+```
+
 ## Release History
 
 [See the CHANGELOG](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To override the config file path, you would add this to the Sublime Linter User 
 }
 ```
 
-If you are using Bundler and would like to use the locked rubocop version (which will also allow you to use `inherit_gem` in `rubocop.yml`, in case you are inheriting from another gem in the project), you must set `use_bundle_exec` to true:
+If you are using Bundler and would like to use the locked slim_lint version, you must set `use_bundle_exec` to true:
 
 ```json
 "slimlint": {

--- a/linter.py
+++ b/linter.py
@@ -1,8 +1,9 @@
 #
 # linter.py
-# Linter for SublimeLinter3, a code checking framework for Sublime Text 3
+# Linter for SublimeLinter4, a code checking framework for Sublime Text 3
 #
 # Written by Gavin Elster
+# Contributors: Richard Baptist
 # Copyright (c) 2015 Gavin Elster
 #
 # License: MIT
@@ -10,18 +11,15 @@
 
 """This module exports the SlimLint plugin class."""
 
-import os
-from SublimeLinter.lint import RubyLinter, util
+from SublimeLinter.lint import RubyLinter
 
 
 class SlimLint(RubyLinter):
-
     """Provides an interface to slim-lint."""
 
     syntax = 'ruby slim'
-    cmd = 'ruby -S slim-lint'
+    cmd = None
     tempfile_suffix = '.slim'
-    config_file = ('--config', '.slim-lint.yml', '~')
 
     version_args = '-S slim-lint --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
@@ -33,21 +31,20 @@ class SlimLint(RubyLinter):
         r'(?P<message>[^`]*(?:`(?P<near>.+?)`)?.*)'
     )
 
-    def build_args(self, settings):
-        """
-        Return a list of args to add to cls.cmd.
+    def cmd(self):
+        """Build the command to run slim-lint."""
+        settings = self.get_view_settings()
 
-        We hook into this method to find the rubocop config and set it as an
-        environment variable for the rubocop linter to pick up.
-        """
+        rubocop_config_file = settings.get('rubocop_config', False)
 
-        if self.filename:
-            config = util.find_file(
-                os.path.dirname(self.filename),
-                '.rubocop.yml',
-                aux_dirs='~'
-            )
-            if config:
-                self.env["SLIM_LINT_RUBOCOP_CONF"] = config
+        if rubocop_config_file:
+            self.env["SLIM_LINT_RUBOCOP_CONF"] = rubocop_config_file
 
-        return super().build_args(settings)
+        command = ['ruby', '-S']
+
+        if settings.get('use_bundle_exec', False):
+            command.extend(['bundle', 'exec'])
+
+        command.extend(['slim-lint'])
+
+        return command


### PR DESCRIPTION
The current version is broken with the latest SublimeLinter release, due to `utils.find_file` no longer being available.

I know I removed the autodetection of the `.rubocop.yml` file, but honestly, I am not that familiar with Python.

I was more focused on getting a working package. The extra features could be added back by someone else if required.