### PR TITLE
Fix install flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SublimeLinter-slim-lint Changelog
 
+## 3.2.0 (1/22/2020)
+
+#### Fixed
+
+* Fixed loading for new syntax on sublimelinter
+
 ## 3.1.0 (3/13/2018)
 
 #### Fixed

--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,6 @@ from SublimeLinter.lint import RubyLinter
 class SlimLint(RubyLinter):
     """Provides an interface to slim-lint."""
 
-    cmd = None
     tempfile_suffix = '.slim'
 
     regex = (

--- a/linter.py
+++ b/linter.py
@@ -27,10 +27,7 @@ class SlimLint(RubyLinter):
     )
 
     defaults = {
-        'selector': 'source.slim, source.html.slim',
-        '--ignore=,': '',
-        '--warn=,': '',
-        '--error=,': '',
+        'selector': 'text.slim',
         '--config': '${folder}/.slim-lint.yml',
         'env': {
            'SLIM_LINT_RUBOCOP_CONF': '${folder}/.rubocop.yml'

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class SlimLint(RubyLinter):
     """Provides an interface to slim-lint."""
 
     cmd = None
-    tempfile_suffix = '.slim'
+    tempfile_suffix = '${temp_file}.slim'
 
     regex = (
         r'^.+?:(?P<line>\d+) '
@@ -36,7 +36,7 @@ class SlimLint(RubyLinter):
 
     def cmd(self):
         """Build the command to run slim-lint."""
-        settings = self.get_view_settings()
+        settings = self.settings
 
         command = ['ruby', '-S']
 

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class SlimLint(RubyLinter):
     """Provides an interface to slim-lint."""
 
     cmd = None
-    tempfile_suffix = '${temp_file}.slim'
+    tempfile_suffix = '.slim'
 
     regex = (
         r'^.+?:(?P<line>\d+) '

--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,6 @@ from SublimeLinter.lint import RubyLinter
 class SlimLint(RubyLinter):
     """Provides an interface to slim-lint."""
 
-    syntax = 'ruby slim'
     cmd = None
     tempfile_suffix = '.slim'
 
@@ -32,6 +31,7 @@ class SlimLint(RubyLinter):
     )
 
     defaults = {
+        'selector': 'source.slim',
         '--config': '${folder}/.slim-lint.yml',
         'env': {
            'SLIM_LINT_RUBOCOP_CONF': '${folder}/.rubocop.yml'

--- a/linter.py
+++ b/linter.py
@@ -20,10 +20,6 @@ class SlimLint(RubyLinter):
     cmd = None
     tempfile_suffix = '.slim'
 
-    version_args = '-S slim-lint --version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.5.0'
-
     regex = (
         r'^.+?:(?P<line>\d+) '
         r'(?:(?P<error>\[E\])|(?P<warning>\[W\])) '
@@ -31,7 +27,10 @@ class SlimLint(RubyLinter):
     )
 
     defaults = {
-        'selector': 'source.slim',
+        'selector': 'source.slim, source.html.slim',
+        '--ignore=,': '',
+        '--warn=,': '',
+        '--error=,': '',
         '--config': '${folder}/.slim-lint.yml',
         'env': {
            'SLIM_LINT_RUBOCOP_CONF': '${folder}/.rubocop.yml'

--- a/messages.json
+++ b/messages.json
@@ -2,5 +2,6 @@
     "install": "messages/install.txt",
     "2.0.0": "messages/2.0.0.txt",
     "3.0.0": "messages/3.0.0.txt",
-    "3.1.0": "messages/3.1.0.txt"
+    "3.1.0": "messages/3.1.0.txt",
+    "3.2.0": "messages/3.2.0.txt"
 }

--- a/messages/3.2.0.txt
+++ b/messages/3.2.0.txt
@@ -1,0 +1,5 @@
+
+SublimeLinter-slim-lint 3.2.0
+-----------------------------
+
+* Fixes build configuration to use with new linter syntax


### PR DESCRIPTION
This updates the linter.py initializer to be able to use the linter in sublime with the updated syntax, there are still some warning on the console, but is fully functional as is.